### PR TITLE
Fix bug: clone fabric-samples error #159

### DIFF
--- a/test/bootstraps/bootstrap-v2.2.sh
+++ b/test/bootstraps/bootstrap-v2.2.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+#
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Download from: https://raw.githubusercontent.com/hyperledger/fabric/release-2.2/scripts/bootstrap.sh
+
+# if version not passed in, default to latest released version
+VERSION=2.2.2
+# if ca version not passed in, default to latest released version
+CA_VERSION=1.4.9
+ARCH=$(echo "$(uname -s|tr '[:upper:]' '[:lower:]'|sed 's/mingw64_nt.*/windows/')-$(uname -m | sed 's/x86_64/amd64/g')")
+MARCH=$(uname -m)
+
+printHelp() {
+    echo "Usage: bootstrap.sh [version [ca_version]] [options]"
+    echo
+    echo "options:"
+    echo "-h : this help"
+    echo "-d : bypass docker image download"
+    echo "-s : bypass fabric-samples repo clone"
+    echo "-b : bypass download of platform-specific binaries"
+    echo
+    echo "e.g. bootstrap.sh 2.2.2 1.4.9 -s"
+    echo "will download docker images and binaries for Fabric v2.2.2 and Fabric CA v1.4.9"
+}
+
+# dockerPull() pulls docker images from fabric and chaincode repositories
+# note, if a docker image doesn't exist for a requested release, it will simply
+# be skipped, since this script doesn't terminate upon errors.
+
+dockerPull() {
+    #three_digit_image_tag is passed in, e.g. "1.4.7"
+    three_digit_image_tag=$1
+    shift
+    #two_digit_image_tag is derived, e.g. "1.4", especially useful as a local tag for two digit references to most recent baseos, ccenv, javaenv, nodeenv patch releases
+    two_digit_image_tag=$(echo "$three_digit_image_tag" | cut -d'.' -f1,2)
+    while [[ $# -gt 0 ]]
+    do
+        image_name="$1"
+        echo "====> hyperledger/fabric-$image_name:$three_digit_image_tag"
+        docker pull "hyperledger/fabric-$image_name:$three_digit_image_tag"
+        docker tag "hyperledger/fabric-$image_name:$three_digit_image_tag" "hyperledger/fabric-$image_name"
+        docker tag "hyperledger/fabric-$image_name:$three_digit_image_tag" "hyperledger/fabric-$image_name:$two_digit_image_tag"
+        shift
+    done
+}
+
+cloneSamplesRepo() {
+    # clone (if needed) hyperledger/fabric-samples and checkout corresponding
+    # version to the binaries and docker images to be downloaded
+    if [ -d first-network ]; then
+        # if we are in the fabric-samples repo, checkout corresponding version
+        echo "===> Checking out v${VERSION} of hyperledger/fabric-samples"
+        git checkout v${VERSION}
+    elif [ -d fabric-samples ]; then
+        # if fabric-samples repo already cloned and in current directory,
+        # cd fabric-samples and checkout corresponding version
+        echo "===> Checking out v${VERSION} of hyperledger/fabric-samples"
+        cd fabric-samples && git checkout v${VERSION}
+    else
+        echo "===> Cloning hyperledger/fabric-samples repo and checkout v${VERSION}"
+        git clone -b main https://github.com/hyperledger/fabric-samples.git && cd fabric-samples && git checkout v${VERSION}
+    fi
+}
+
+# This will download the .tar.gz
+download() {
+    local BINARY_FILE=$1
+    local URL=$2
+    echo "===> Downloading: " "${URL}"
+    curl -L --retry 5 --retry-delay 3 "${URL}" | tar xz || rc=$?
+    if [ -n "$rc" ]; then
+        echo "==> There was an error downloading the binary file."
+        return 22
+    else
+        echo "==> Done."
+    fi
+}
+
+pullBinaries() {
+    echo "===> Downloading version ${FABRIC_TAG} platform specific fabric binaries"
+    download "${BINARY_FILE}" "https://github.com/hyperledger/fabric/releases/download/v${VERSION}/${BINARY_FILE}"
+    if [ $? -eq 22 ]; then
+        echo
+        echo "------> ${FABRIC_TAG} platform specific fabric binary is not available to download <----"
+        echo
+        exit
+    fi
+
+    echo "===> Downloading version ${CA_TAG} platform specific fabric-ca-client binary"
+    download "${CA_BINARY_FILE}" "https://github.com/hyperledger/fabric-ca/releases/download/v${CA_VERSION}/${CA_BINARY_FILE}"
+    if [ $? -eq 22 ]; then
+        echo
+        echo "------> ${CA_TAG} fabric-ca-client binary is not available to download  (Available from 1.1.0-rc1) <----"
+        echo
+        exit
+    fi
+}
+
+pullDockerImages() {
+    command -v docker >& /dev/null
+    NODOCKER=$?
+    if [ "${NODOCKER}" == 0 ]; then
+        FABRIC_IMAGES=(peer orderer ccenv tools)
+        case "$VERSION" in
+        1.*)
+            FABRIC_IMAGES+=(javaenv)
+            shift
+            ;;
+        2.*)
+            FABRIC_IMAGES+=(nodeenv baseos javaenv)
+            shift
+            ;;
+        esac
+        echo "FABRIC_IMAGES:" "${FABRIC_IMAGES[@]}"
+        echo "===> Pulling fabric Images"
+        dockerPull "${FABRIC_TAG}" "${FABRIC_IMAGES[@]}"
+        echo "===> Pulling fabric ca Image"
+        CA_IMAGE=(ca)
+        dockerPull "${CA_TAG}" "${CA_IMAGE[@]}"
+        echo "===> List out hyperledger docker images"
+        docker images | grep hyperledger
+    else
+        echo "========================================================="
+        echo "Docker not installed, bypassing download of Fabric images"
+        echo "========================================================="
+    fi
+}
+
+DOCKER=true
+SAMPLES=true
+BINARIES=true
+
+# Parse commandline args pull out
+# version and/or ca-version strings first
+if [ -n "$1" ] && [ "${1:0:1}" != "-" ]; then
+    VERSION=$1;shift
+    if [ -n "$1" ]  && [ "${1:0:1}" != "-" ]; then
+        CA_VERSION=$1;shift
+        if [ -n  "$1" ] && [ "${1:0:1}" != "-" ]; then
+            THIRDPARTY_IMAGE_VERSION=$1;shift
+        fi
+    fi
+fi
+
+# prior to 1.2.0 architecture was determined by uname -m
+if [[ $VERSION =~ ^1\.[0-1]\.* ]]; then
+    export FABRIC_TAG=${MARCH}-${VERSION}
+    export CA_TAG=${MARCH}-${CA_VERSION}
+    export THIRDPARTY_TAG=${MARCH}-${THIRDPARTY_IMAGE_VERSION}
+else
+    # starting with 1.2.0, multi-arch images will be default
+    : "${CA_TAG:="$CA_VERSION"}"
+    : "${FABRIC_TAG:="$VERSION"}"
+    : "${THIRDPARTY_TAG:="$THIRDPARTY_IMAGE_VERSION"}"
+fi
+
+BINARY_FILE=hyperledger-fabric-${ARCH}-${VERSION}.tar.gz
+CA_BINARY_FILE=hyperledger-fabric-ca-${ARCH}-${CA_VERSION}.tar.gz
+
+# then parse opts
+while getopts "h?dsb" opt; do
+    case "$opt" in
+        h|\?)
+            printHelp
+            exit 0
+            ;;
+        d)  DOCKER=false
+            ;;
+        s)  SAMPLES=false
+            ;;
+        b)  BINARIES=false
+            ;;
+    esac
+done
+
+if [ "$SAMPLES" == "true" ]; then
+    echo
+    echo "Clone hyperledger/fabric-samples repo"
+    echo
+    cloneSamplesRepo
+fi
+if [ "$BINARIES" == "true" ]; then
+    echo
+    echo "Pull Hyperledger Fabric binaries"
+    echo
+    pullBinaries
+fi
+if [ "$DOCKER" == "true" ]; then
+    echo
+    echo "Pull Hyperledger Fabric docker images"
+    echo
+    pullDockerImages
+fi

--- a/test/bootstraps/bootstrap-v2.3.sh
+++ b/test/bootstraps/bootstrap-v2.3.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+#
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Download from: https://raw.githubusercontent.com/hyperledger/fabric/release-2.3/scripts/bootstrap.sh
+
+# if version not passed in, default to latest released version
+VERSION=2.3.1
+# if ca version not passed in, default to latest released version
+CA_VERSION=1.4.9
+ARCH=$(echo "$(uname -s|tr '[:upper:]' '[:lower:]'|sed 's/mingw64_nt.*/windows/')-$(uname -m | sed 's/x86_64/amd64/g')")
+MARCH=$(uname -m)
+
+printHelp() {
+    echo "Usage: bootstrap.sh [version [ca_version]] [options]"
+    echo
+    echo "options:"
+    echo "-h : this help"
+    echo "-d : bypass docker image download"
+    echo "-s : bypass fabric-samples repo clone"
+    echo "-b : bypass download of platform-specific binaries"
+    echo
+    echo "e.g. bootstrap.sh 2.3.1 1.4.9 -s"
+    echo "will download docker images and binaries for Fabric v2.3.1 and Fabric CA v1.4.9"
+}
+
+# dockerPull() pulls docker images from fabric and chaincode repositories
+# note, if a docker image doesn't exist for a requested release, it will simply
+# be skipped, since this script doesn't terminate upon errors.
+
+dockerPull() {
+    #three_digit_image_tag is passed in, e.g. "1.4.7"
+    three_digit_image_tag=$1
+    shift
+    #two_digit_image_tag is derived, e.g. "1.4", especially useful as a local tag for two digit references to most recent baseos, ccenv, javaenv, nodeenv patch releases
+    two_digit_image_tag=$(echo "$three_digit_image_tag" | cut -d'.' -f1,2)
+    while [[ $# -gt 0 ]]
+    do
+        image_name="$1"
+        echo "====> hyperledger/fabric-$image_name:$three_digit_image_tag"
+        docker pull "hyperledger/fabric-$image_name:$three_digit_image_tag"
+        docker tag "hyperledger/fabric-$image_name:$three_digit_image_tag" "hyperledger/fabric-$image_name"
+        docker tag "hyperledger/fabric-$image_name:$three_digit_image_tag" "hyperledger/fabric-$image_name:$two_digit_image_tag"
+        shift
+    done
+}
+
+cloneSamplesRepo() {
+    # clone (if needed) hyperledger/fabric-samples and checkout corresponding
+    # version to the binaries and docker images to be downloaded
+    if [ -d first-network ]; then
+        # if we are in the fabric-samples repo, checkout corresponding version
+        echo "==> Already in fabric-samples repo"
+    elif [ -d fabric-samples ]; then
+        # if fabric-samples repo already cloned and in current directory,
+        # cd fabric-samples
+        echo "===> Changing directory to fabric-samples"
+        cd fabric-samples
+    else
+        echo "===> Cloning hyperledger/fabric-samples repo"
+        git clone -b main https://github.com/hyperledger/fabric-samples.git && cd fabric-samples
+    fi
+
+    if GIT_DIR=.git git rev-parse v${VERSION} >/dev/null 2>&1; then
+        echo "===> Checking out v${VERSION} of hyperledger/fabric-samples"
+        git checkout -q v${VERSION}
+    else
+        echo "fabric-samples v${VERSION} does not exist, defaulting main"
+        git checkout -q main
+    fi
+}
+
+# This will download the .tar.gz
+download() {
+    local BINARY_FILE=$1
+    local URL=$2
+    echo "===> Downloading: " "${URL}"
+    curl -L --retry 5 --retry-delay 3 "${URL}" | tar xz || rc=$?
+    if [ -n "$rc" ]; then
+        echo "==> There was an error downloading the binary file."
+        return 22
+    else
+        echo "==> Done."
+    fi
+}
+
+pullBinaries() {
+    echo "===> Downloading version ${FABRIC_TAG} platform specific fabric binaries"
+    download "${BINARY_FILE}" "https://github.com/hyperledger/fabric/releases/download/v${VERSION}/${BINARY_FILE}"
+    if [ $? -eq 22 ]; then
+        echo
+        echo "------> ${FABRIC_TAG} platform specific fabric binary is not available to download <----"
+        echo
+        exit
+    fi
+
+    echo "===> Downloading version ${CA_TAG} platform specific fabric-ca-client binary"
+    download "${CA_BINARY_FILE}" "https://github.com/hyperledger/fabric-ca/releases/download/v${CA_VERSION}/${CA_BINARY_FILE}"
+    if [ $? -eq 22 ]; then
+        echo
+        echo "------> ${CA_TAG} fabric-ca-client binary is not available to download  (Available from 1.1.0-rc1) <----"
+        echo
+        exit
+    fi
+}
+
+pullDockerImages() {
+    command -v docker >& /dev/null
+    NODOCKER=$?
+    if [ "${NODOCKER}" == 0 ]; then
+        FABRIC_IMAGES=(peer orderer ccenv tools)
+        case "$VERSION" in
+        2.*)
+            FABRIC_IMAGES+=(baseos)
+            shift
+            ;;
+        esac
+        echo "FABRIC_IMAGES:" "${FABRIC_IMAGES[@]}"
+        echo "===> Pulling fabric Images"
+        dockerPull "${FABRIC_TAG}" "${FABRIC_IMAGES[@]}"
+        echo "===> Pulling fabric ca Image"
+        CA_IMAGE=(ca)
+        dockerPull "${CA_TAG}" "${CA_IMAGE[@]}"
+        echo "===> List out hyperledger docker images"
+        docker images | grep hyperledger
+    else
+        echo "========================================================="
+        echo "Docker not installed, bypassing download of Fabric images"
+        echo "========================================================="
+    fi
+}
+
+DOCKER=true
+SAMPLES=true
+BINARIES=true
+
+# Parse commandline args pull out
+# version and/or ca-version strings first
+if [ -n "$1" ] && [ "${1:0:1}" != "-" ]; then
+    VERSION=$1;shift
+    if [ -n "$1" ]  && [ "${1:0:1}" != "-" ]; then
+        CA_VERSION=$1;shift
+        if [ -n  "$1" ] && [ "${1:0:1}" != "-" ]; then
+            THIRDPARTY_IMAGE_VERSION=$1;shift
+        fi
+    fi
+fi
+
+# prior to 1.2.0 architecture was determined by uname -m
+if [[ $VERSION =~ ^1\.[0-1]\.* ]]; then
+    export FABRIC_TAG=${MARCH}-${VERSION}
+    export CA_TAG=${MARCH}-${CA_VERSION}
+    export THIRDPARTY_TAG=${MARCH}-${THIRDPARTY_IMAGE_VERSION}
+else
+    # starting with 1.2.0, multi-arch images will be default
+    : "${CA_TAG:="$CA_VERSION"}"
+    : "${FABRIC_TAG:="$VERSION"}"
+    : "${THIRDPARTY_TAG:="$THIRDPARTY_IMAGE_VERSION"}"
+fi
+
+BINARY_FILE=hyperledger-fabric-${ARCH}-${VERSION}.tar.gz
+CA_BINARY_FILE=hyperledger-fabric-ca-${ARCH}-${CA_VERSION}.tar.gz
+
+# then parse opts
+while getopts "h?dsb" opt; do
+    case "$opt" in
+        h|\?)
+            printHelp
+            exit 0
+            ;;
+        d)  DOCKER=false
+            ;;
+        s)  SAMPLES=false
+            ;;
+        b)  BINARIES=false
+            ;;
+    esac
+done
+
+if [ "$SAMPLES" == "true" ]; then
+    echo
+    echo "Clone hyperledger/fabric-samples repo"
+    echo
+    cloneSamplesRepo
+fi
+if [ "$BINARIES" == "true" ]; then
+    echo
+    echo "Pull Hyperledger Fabric binaries"
+    echo
+    pullBinaries
+fi
+if [ "$DOCKER" == "true" ]; then
+    echo
+    echo "Pull Hyperledger Fabric docker images"
+    echo
+    pullDockerImages
+fi

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -12,7 +12,7 @@ case $1 in
     # sadly, bootstrap.sh from release-1.4 still pulls binaries from Nexus, which is not available anymore
     # Why comment following code? Please check this issue: https://github.com/Hyperledger-TWGC/tape/issues/159
     # curl -vsS https://raw.githubusercontent.com/hyperledger/fabric/release-2.2/scripts/bootstrap.sh | bash
-    ./test/bootstrap/bootstrap-v2.2.sh
+    ./test/bootstraps/bootstrap-v2.2.sh
     cd ./fabric-samples/
     git checkout release-1.4
     cd ./first-network
@@ -45,7 +45,7 @@ case $1 in
  2_3)
     # Why comment following code? Please check this issue: https://github.com/Hyperledger-TWGC/tape/issues/159
     # curl -vsS https://raw.githubusercontent.com/hyperledger/fabric/release-2.3/scripts/bootstrap.sh | bash
-    ./test/bootstrap/bootstrap-v2.3.sh
+    ./test/bootstraps/bootstrap-v2.3.sh
     cd ./fabric-samples/test-network
     echo y |  ./network.sh down
     echo y |  ./network.sh up createChannel

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -10,7 +10,9 @@ case $1 in
  1_4)
     unset COMPOSE_PROJECT_NAME
     # sadly, bootstrap.sh from release-1.4 still pulls binaries from Nexus, which is not available anymore
-    curl -vsS https://raw.githubusercontent.com/hyperledger/fabric/release-2.2/scripts/bootstrap.sh | bash
+    # Why comment following code? Please check this issue: https://github.com/Hyperledger-TWGC/tape/issues/159
+    # curl -vsS https://raw.githubusercontent.com/hyperledger/fabric/release-2.2/scripts/bootstrap.sh | bash
+    ./bootstrap/bootstrap-v2.2.sh
     cd ./fabric-samples/
     git checkout release-1.4
     cd ./first-network
@@ -41,7 +43,9 @@ case $1 in
     echo y |  ./network.sh deployCC -ccn basic -ccp ../asset-transfer-basic/chaincode-go/ -ccl go "${ARGS[@]}"
     ;;
  2_3)
-    curl -vsS https://raw.githubusercontent.com/hyperledger/fabric/release-2.3/scripts/bootstrap.sh | bash
+    # Why comment following code? Please check this issue: https://github.com/Hyperledger-TWGC/tape/issues/159
+    # curl -vsS https://raw.githubusercontent.com/hyperledger/fabric/release-2.3/scripts/bootstrap.sh | bash
+    ./bootstrap/bootstrap-v2.3.sh
     cd ./fabric-samples/test-network
     echo y |  ./network.sh down
     echo y |  ./network.sh up createChannel

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -12,7 +12,7 @@ case $1 in
     # sadly, bootstrap.sh from release-1.4 still pulls binaries from Nexus, which is not available anymore
     # Why comment following code? Please check this issue: https://github.com/Hyperledger-TWGC/tape/issues/159
     # curl -vsS https://raw.githubusercontent.com/hyperledger/fabric/release-2.2/scripts/bootstrap.sh | bash
-    ./bootstrap/bootstrap-v2.2.sh
+    ./test/bootstrap/bootstrap-v2.2.sh
     cd ./fabric-samples/
     git checkout release-1.4
     cd ./first-network
@@ -45,7 +45,7 @@ case $1 in
  2_3)
     # Why comment following code? Please check this issue: https://github.com/Hyperledger-TWGC/tape/issues/159
     # curl -vsS https://raw.githubusercontent.com/hyperledger/fabric/release-2.3/scripts/bootstrap.sh | bash
-    ./bootstrap/bootstrap-v2.3.sh
+    ./test/bootstrap/bootstrap-v2.3.sh
     cd ./fabric-samples/test-network
     echo y |  ./network.sh down
     echo y |  ./network.sh up createChannel


### PR DESCRIPTION
Fix #159 
问题详情不再赘述，请查看 issue

**修复步骤：**
1、将涉及到的 `bootstrap.sh` 脚本代码内容从源 url 复制到 `$(root_dir)/test/bootstraps/` 目录下。
2、将 `bootstrap.sh` 中 clone fabric-samples 项目部分的代码修改为从 **main** 分支 clone。
3、修改坚持最小改动原则，只修改了 `release-2.2` 和 `release-2.3` 版本的 bootstrap 脚本，另外两处的 bootstrap 脚本代码不存在该问题。

此问题涉及到的 `intergration-test.sh` 代码：
```
case $1 in
 1_4)
# 省略了不涉及的代码
    # sadly, bootstrap.sh from release-1.4 still pulls binaries from Nexus, which is not available anymore
    # Why comment following code? Please check this issue: https://github.com/Hyperledger-TWGC/tape/issues/159
    # curl -vsS https://raw.githubusercontent.com/hyperledger/fabric/release-2.2/scripts/bootstrap.sh | bash
    ./test/bootstraps/bootstrap-v2.2.sh
# 省略了不涉及的代码
2_3)
    # Why comment following code? Please check this issue: https://github.com/Hyperledger-TWGC/tape/issues/159
    # curl -vsS https://raw.githubusercontent.com/hyperledger/fabric/release-2.3/scripts/bootstrap.sh | bash
    ./test/bootstraps/bootstrap-v2.3.sh
    cd ./fabric-samples/test-network
# 省略了不涉及的代码
```

`bootstrap-v2.2.sh` 代码修改：
```
cloneSamplesRepo() {
# 省略了不涉及的代码
    else
        echo "===> Cloning hyperledger/fabric-samples repo and checkout v${VERSION}"
        # master -> main
        git clone -b main https://github.com/hyperledger/fabric-samples.git && cd fabric-samples && git checkout v${VERSION}
    fi
}
```

`bootstrap-v2.3.sh` 代码修改：
```
cloneSamplesRepo() {
# 省略了不涉及的代码
    else
        echo "===> Cloning hyperledger/fabric-samples repo"
        # master -> main
        git clone -b main https://github.com/hyperledger/fabric-samples.git && cd fabric-samples
    fi

    if GIT_DIR=.git git rev-parse v${VERSION} >/dev/null 2>&1; then
        echo "===> Checking out v${VERSION} of hyperledger/fabric-samples"
        git checkout -q v${VERSION}
    else
        # master -> main
        echo "fabric-samples v${VERSION} does not exist, defaulting main"
        git checkout -q main
    fi
}
```