### PR TITLE
reproduce the bug on ci as requested by @SamYuan1990

### DIFF
--- a/test/config20org1andorg2.yaml
+++ b/test/config20org1andorg2.yaml
@@ -30,7 +30,12 @@ orderer: *orderer1
 channel: mychannel
 chaincode: basic
 args:
-  - GetAllAssets
+  - CreateAsset
+  - 0
+  - blue
+  - 20
+  - penguin
+  - 500
 mspid: Org1MSP
 private_key: /config/organizations/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/keystore/priv_sk
 sign_cert: /config/organizations/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/signcerts/User1@org1.example.com-cert.pem

--- a/test/config20selectendorser.yaml
+++ b/test/config20selectendorser.yaml
@@ -29,7 +29,8 @@ orderer: *orderer1
 channel: mychannel
 chaincode: basic
 args:
-  - GetAllAssets
+  - ReadAsset
+  - 0
 mspid: Org1MSP
 private_key: /config/organizations/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/keystore/priv_sk
 sign_cert: /config/organizations/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/signcerts/User1@org1.example.com-cert.pem


### PR DESCRIPTION
cc @SamYuan1990 

something like [caliper tutorial](https://hyperledger.github.io/caliper/v0.4.2/fabric-tutorial/tutorials-fabric-existing/)

```nodejs
        for (let i=0; i<this.roundArguments.assets; i++) {
            const assetID = `${this.workerIndex}_${i}`;
            console.log(`Worker ${this.workerIndex}: Creating asset ${assetID}`);
            const request = {
                contractId: this.roundArguments.contractId,
                contractFunction: 'CreateAsset',
                invokerIdentity: 'User1',
                contractArguments: [assetID,'blue','20','penguin','500'],
                readOnly: false
            };
```
but tape is not able to use dynamic arguments so I fixed the id to 0