### PR TITLE
try to update CI sample to match with 2.2

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,1 +1,4 @@
 # FAQ 常见问题
+
+## Q：是否[初始化智能合约问题](https://github.com/Hyperledger-TWGC/tape/issues/181)？
+## A:Tape目前并不部署fabric网络，因此需要手工调用智能合约。以fabric-sample为例的参考[CI中的实现以及改动](https://github.com/Hyperledger-TWGC/tape/pull/184)

--- a/test/config20org1andorg2.yaml
+++ b/test/config20org1andorg2.yaml
@@ -30,7 +30,8 @@ orderer: *orderer1
 channel: mychannel
 chaincode: basic
 args:
-  - GetAllAssets
+  - ReadAsset
+  - asset1
 mspid: Org1MSP
 private_key: /config/organizations/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/keystore/priv_sk
 sign_cert: /config/organizations/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/signcerts/User1@org1.example.com-cert.pem

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -38,6 +38,8 @@ case $1 in
     if [ $2 == "ORLogic" ]; then
       CONFIG_FILE=/config/test/config20selectendorser.yaml
       ARGS=(-ccep "OR('Org1.member','Org2.member')")
+    else
+      ARGS=(-cci initLedger)
     fi
 
     echo y |  ./network.sh deployCC -ccn basic -ccp ../asset-transfer-basic/chaincode-go/ -ccl go "${ARGS[@]}"
@@ -56,6 +58,8 @@ case $1 in
     if [ $2 == "ORLogic" ]; then
       CONFIG_FILE=/config/test/config20selectendorser.yaml
       ARGS=(-ccep "OR('Org1.member','Org2.member')")
+    else
+      ARGS=(-cci initLedger)
     fi
 
     echo y |  ./network.sh deployCC -ccn basic -ccp ../asset-transfer-basic/chaincode-go/ -ccl go "${ARGS[@]}"
@@ -72,7 +76,10 @@ case $1 in
     if [ $2 == "ORLogic" ]; then
       CONFIG_FILE=/config/test/config20selectendorser.yaml
       ARGS=(-ccep "OR('Org1.member','Org2.member')")
+    else
+      ARGS=(-cci initLedger)
     fi
+    
 
     echo y |  ./network.sh deployCC -ccn basic -ccp ../asset-transfer-basic/chaincode-go/ -ccl go "${ARGS[@]}"
     ;;
@@ -87,4 +94,6 @@ esac
 cd "$DIR"
 docker ps -a
 docker network ls
+## warm up for the init chaincode block
+sleep 10
 docker run  -e TAPE_LOGLEVEL=debug --network $network -v $PWD:/config tape tape -c $CONFIG_FILE -n 500


### PR DESCRIPTION
try to update CI sample to match with 2.2, as 1.4 removed from LTS, we need a sample in CI for test with parameters.

and a sample for https://github.com/Hyperledger-TWGC/tape/issues/181

Signed-off-by: Sam Yuan <yy19902439@126.com>