### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
-  pull_request:
+  
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: hyperledger-twgc/tape


### PR DESCRIPTION
in most of cases, github workflow for release purpose should not be triggered by PR.