### PR TITLE
add --prometheus-addr option

### DIFF
--- a/cmd/tape/main.go
+++ b/cmd/tape/main.go
@@ -118,13 +118,17 @@ func checkArgs(rate *float64, burst, signerNumber, parallel *int, con string, en
 	}
 
 	// enable prometheus but not provide --prometheus-addr option, use default prometheus address ":8080"
-	if enablePrometheus && len(*prometheusAddr) == 0 {
-		*prometheusAddr = DEFAULT_PROMETHEUS_ADDR
+	if enablePrometheus {
+		if len(*prometheusAddr) == 0 {
+			*prometheusAddr = DEFAULT_PROMETHEUS_ADDR
+		}
+		logger.Infof("prometheus running at %s\n", *prometheusAddr)
 	}
 
 	// not enable prometheus but provide --prometheus-addr option, show help message
 	if !enablePrometheus && len(*prometheusAddr) != 0 {
 		fmt.Printf("You've provided the --prometheus-addr option to specify a Prometheus address, but you haven't enabled Prometheus using --prometheus option\n")
+		logger.Warnf("prometheus is not available at %s, because --prometheus option is not provided\n", *prometheusAddr)
 	}
 
 	logger.Infof("Will use rate %f as send rate\n", *rate)


### PR DESCRIPTION
This enhancement expands the Prometheus integration capabilities by introducing the `--prometheus-addr` option, which enables users to specify a custom address for the Prometheus service.

The following example shows tape how to start the Prometheus service on port 9090 with `--prometheus-addr` option
```shell
./tape --config=config.yaml --number=40000 --prometheus --prometheus-addr :9090
```

If user does not enable Prometheus service but specify service address
```shell
./tape --config=config.yaml --number=40000 --prometheus-addr :9090
```
tape will give user this help message `You've provided the --prometheus-addr option to specify a Prometheus address, but you haven't enabled Prometheus using --prometheus option`

This feature doesn't disrupt existing functionality. It's backward-compatible, so projects using the traditional `--prometheus` option on the default `:8080` address will continue to work as expected.