### PR TITLE
ref to github sample add depbot auto merge

### DIFF
--- a/.github/workflows/depbot-auto.yml
+++ b/.github/workflows/depbot-auto.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
ref to github.com/prometheus/client_golang/pull/1420 and https://github.com/prometheus/client_golang/blob/main/.github/workflows/automerge-dependabot.yml make a auto merge dep bot config.
@davidkhala , @ryjones , would you like to help config a token and let's have a try?